### PR TITLE
Used a supported base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:9-jre
 MAINTAINER Atlassian Confluence
 
 # Setup useful environment variables


### PR DESCRIPTION
The "java" image was deprecated in dockerhub and hasn't been receiving
updates since Dec 31, 2016!